### PR TITLE
- adapt stage and seeds naming to config refactor

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -32,8 +32,8 @@ local function despawnPlants()
     for _, v in pairs(housePlants[currentHouse]) do
         for _, stage in pairs(sharedConfig.plants[v.sort].stages) do
             deleteClosestPlant(stage, v)
-            v = nil
         end
+        v = nil
     end
     plantsSpawned = false
 end
@@ -50,10 +50,10 @@ local function updatePlantStats()
             closestTarget = k
             if v.health > 0 then
                 if v.stage ~= sharedConfig.plants[v.sort].highestStage then
-                    local label = ('%s%s~w~ [%s] | %s ~b~%s% ~w~ | %s ~b~%s%'):format(locale('text.sort'), sharedConfig.plants[v.sort].label, gender, locale('text.nutrition'), v.food, locale('text.health'), v.health)
+                    local label = ('%s%s~w~ [%s] | %s ~b~%s~w~ | %s ~b~%s~w~'):format(locale('text.sort'), sharedConfig.plants[v.sort].label, gender, locale('text.nutrition'), v.food, locale('text.health'), v.health)
                     qbx.drawText3d({text = label, coords = v.coords})
                 else
-                    local label = ('%s ~g~%s~w~ [%s] | %s ~b~%s% ~w~ | %s ~b~%s%'):format(locale('text.sort'), sharedConfig.plants[v.sort].label, gender, locale('text.nutrition'), v.food, locale('text.health'), v.health)
+                    local label = ('%s ~g~%s~w~ [%s] | %s ~b~%s~w~ | %s ~b~%s~w~'):format(locale('text.sort'), sharedConfig.plants[v.sort].label, gender, locale('text.nutrition'), v.food, locale('text.health'), v.health)
                     qbx.drawText3d({text = locale('text.harvest_plant'), coords = vec3(v.coords.x, v.coords.y, v.coords.z + 0.2)})
                     qbx.drawText3d({text = label, coords = v.coords})
                     if IsControlJustPressed(0, 38) then
@@ -201,7 +201,7 @@ RegisterNetEvent('qb-weed:client:placePlant', function(type, item)
             })
             then
                 ClearPedTasks(cache.ped)
-                TriggerServerEvent('qb-weed:server:placePlant', json.encode(plyCoords), type, currentHouse)
+                TriggerServerEvent('qb-weed:server:placePlant', plyCoords, type, currentHouse)
                 TriggerServerEvent('qb-weed:server:removeSeed', item.slot, type)
             else
                 ClearPedTasks(cache.ped)

--- a/client/main.lua
+++ b/client/main.lua
@@ -20,6 +20,8 @@ local function spawnPlants()
 end
 
 local function deleteClosestPlant(plantStage, plantData)
+    if not (plantStage or plantData) then return end
+
     local closestPlant = GetClosestObjectOfType(plantData.coords.x, plantData.coords.y, plantData.coords.z, 3.5, joaat(plantStage), false, false, false)
     if closestPlant == 0 then return end
 
@@ -29,12 +31,16 @@ end
 local function despawnPlants()
     if not (plantsSpawned or currentHouse) then return end
 
-    for _, v in pairs(housePlants[currentHouse]) do
-        for _, stage in pairs(sharedConfig.plants[v.sort].stages) do
-            deleteClosestPlant(stage, v)
+    local plants = housePlants[currentHouse]
+
+    for i = #plants, 1, -1 do
+        local plantData = plants[i]
+        for _, stage in pairs(sharedConfig.plants[plantData.sort].stages) do
+            deleteClosestPlant(stage, plantData)
         end
-        v = nil
+        table.remove(plants, i)
     end
+
     plantsSpawned = false
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -20,7 +20,7 @@ local function spawnPlants()
 end
 
 local function deleteClosestPlant(plantStage, plantData)
-    if not (plantStage or plantData) then return end
+    if not (plantStage and plantData) then return end
 
     local closestPlant = GetClosestObjectOfType(plantData.coords.x, plantData.coords.y, plantData.coords.z, 3.5, joaat(plantStage), false, false, false)
     if closestPlant == 0 then return end

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -12,7 +12,7 @@ return {
                 stage6 = 'bkr_prop_weed_lrg_01b',
                 stage7 = 'bkr_prop_weed_lrg_01b',
             },
-            highestStage = 'stage-7'
+            highestStage = 'stage7'
         },
         amnesia = {
             label = 'Amnesia 2g',
@@ -26,7 +26,7 @@ return {
                 stage6 = 'bkr_prop_weed_lrg_01b',
                 stage7 = 'bkr_prop_weed_lrg_01b',
             },
-            highestStage = 'stage-7'
+            highestStage = 'stage7'
         },
         skunk = {
             label = 'Skunk 2g',
@@ -40,7 +40,7 @@ return {
                 stage6 = 'bkr_prop_weed_lrg_01b',
                 stage7 = 'bkr_prop_weed_lrg_01b',
             },
-            highestStage = 'stage-7'
+            highestStage = 'stage7'
         },
         ak47 = {
             label = 'AK47 2g',
@@ -54,7 +54,7 @@ return {
                 stage6 = 'bkr_prop_weed_lrg_01b',
                 stage7 = 'bkr_prop_weed_lrg_01b',
             },
-            highestStage = 'stage-7'
+            highestStage = 'stage7'
         },
         purple_haze = {
             label = 'Purple Haze 2g',
@@ -68,7 +68,7 @@ return {
                 stage6 = 'bkr_prop_weed_lrg_01b',
                 stage7 = 'bkr_prop_weed_lrg_01b',
             },
-            highestStage = 'stage-7'
+            highestStage = 'stage7'
         },
         white_widow = {
             label = 'White Widow 2g',
@@ -82,7 +82,7 @@ return {
                 stage6 = 'bkr_prop_weed_lrg_01b',
                 stage7 = 'bkr_prop_weed_lrg_01b',
             },
-            highestStage = 'stage-7'
+            highestStage = 'stage7'
         },
     },
 

--- a/locales/es.json
+++ b/locales/es.json
@@ -10,7 +10,7 @@
         "you_dont_have_enough_resealable_bags": "No tiene suficientes bolsas"
     },
     "text": {
-        "sort": "Orden:",
+        "sort": "Tipo:",
         "harvest_plant": "Presione ~g~ E ~w~ para cosechar la planta.",
         "nutrition": "Nutrición:",
         "health": "Salud:",

--- a/qb-weed.sql
+++ b/qb-weed.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `house_plants` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `building` varchar(50) DEFAULT NULL,
-  `stage` varchar(50) DEFAULT 'stage-a',
+  `stage` varchar(50) DEFAULT 'stage1',
   `sort` varchar(50) DEFAULT NULL,
   `gender` varchar(50) DEFAULT NULL,
   `food` int(11) DEFAULT 100,
@@ -12,4 +12,4 @@ CREATE TABLE IF NOT EXISTS `house_plants` (
   PRIMARY KEY (`id`),
   KEY `building` (`building`),
   KEY `plantid` (`plantid`)
-) ENGINE=InnoDB AUTO_INCREMENT=7123 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;

--- a/server/main.lua
+++ b/server/main.lua
@@ -61,11 +61,11 @@ local function manageHousePlants()
     end
 end
 
----@param plant table
+---@param plantStage string
 ---@return string nextStage
-local function getNextStage(plant)
-    local initStage = tonumber(string.sub(plant.stage, -1))
-    return 'stage-' .. tostring(initStage + 1)
+local function getNextStage(plantStage)
+    local initStage = tonumber(string.sub(plantStage, -1))
+    return 'stage' .. tostring(initStage + 1)
 end
 
 ---@param plant table
@@ -98,7 +98,7 @@ CreateThread(manageHousePlants)
 CreateThread(updatePlantGrowth)
 
 exports.qbx_core:CreateUseableItem('weed_white-widow_seed', function(source, item)
-    TriggerClientEvent('qb-weed:client:placePlant', source, 'white-widow', item)
+    TriggerClientEvent('qb-weed:client:placePlant', source, 'white_widow', item)
 end)
 
 exports.qbx_core:CreateUseableItem('weed_skunk_seed', function(source, item)
@@ -106,11 +106,11 @@ exports.qbx_core:CreateUseableItem('weed_skunk_seed', function(source, item)
 end)
 
 exports.qbx_core:CreateUseableItem('weed_purple-haze_seed', function(source, item)
-    TriggerClientEvent('qb-weed:client:placePlant', source, 'purple-haze', item)
+    TriggerClientEvent('qb-weed:client:placePlant', source, 'purple_haze', item)
 end)
 
 exports.qbx_core:CreateUseableItem('weed_og-kush_seed', function(source, item)
-    TriggerClientEvent('qb-weed:client:placePlant', source, 'og-kush', item)
+    TriggerClientEvent('qb-weed:client:placePlant', source, 'og_kush', item)
 end)
 
 exports.qbx_core:CreateUseableItem('weed_amnesia_seed', function(source, item)
@@ -153,9 +153,8 @@ RegisterNetEvent('qb-weed:server:harvestPlant', function(house, amount, plantNam
 
     local result = MySQL.query.await('SELECT * FROM house_plants WHERE plantid = ? AND building = ?', { plantId, house })
 
-    if result[1] then
+    if not result[1] then
         exports.qbx_core:Notify(src, locale('error.this_plant_no_longer_exists'), 'error' )
-        MySQL.update.await('UPDATE players SET inventory = ? WHERE citizenid = ?', { '[]', player.PlayerData.citizenid })
         return
     end
 
@@ -163,7 +162,7 @@ RegisterNetEvent('qb-weed:server:harvestPlant', function(house, amount, plantNam
     player.Functions.AddItem('weed_' .. plantName, sndAmount)
     player.Functions.RemoveItem('empty_weed_bag', sndAmount)
     MySQL.query.await('DELETE FROM house_plants WHERE plantid = ? AND building = ?', { plantId, house })
-    exports.qbx_core:Notify(src, locale('text.the_plant_has_been_harvested'), 'success' )
+    exports.qbx_core:Notify(src, locale('text.the_plant_has_been_harvested'), 'success')
     TriggerClientEvent('qb-weed:client:refreshHousePlants', -1, house)
 end)
 


### PR DESCRIPTION
## Description

- adapt stage and seeds naming to config refactor
- move plant data resetting to parent loop in despawnPlants (updated luacheck didnt like setting v to nil)
- fix invalid conversion client issue when drawing plant labels
- remove json.encode for plyCoords already done on server side
- update highestStage values to reflect previous config refactor
- small adjustment for plant sort in Spanish translation (tipo is more accurate imo)
- remove wiping player inventory (please check and confirm)
Solves #22 

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
