### PR TITLE
fix: console error on start

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -6,7 +6,7 @@ local config = require 'config.client'
 local propertyPlants = {}
 ---@type WeedPlant[]
 local outsidePlants = {}
-local currentProperty = exports.qbx_core:GetPlayerData()?.metadata.currentPropertyId
+local currentProperty = exports.qbx_core:GetPlayerData()?.metadata?.currentPropertyId
 local plantsSpawned = false
 local closestTarget = 0
 


### PR DESCRIPTION
## Description

Fixes a client console error on resource start while the player hasn't loaded / selected a character yet.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My pull request fits the contribution guidelines & code conventions.
